### PR TITLE
Load and run llm evaluations

### DIFF
--- a/fixed_evaluation_code.py
+++ b/fixed_evaluation_code.py
@@ -1,0 +1,228 @@
+def auto_generate_evaluation_prompt(metric_name: str, metric_type: str, description: str, grading_rubric: str) -> str:
+    """
+    Auto-generate evaluation prompt from grading rubric.
+    PM just provides grading rubric, code handles the rest!
+    """
+    
+    # Add grading rubric section
+    rubric_section = f"\n**Grading Rubric:**\n{grading_rubric}\n" if grading_rubric else ""
+    
+    # Build complete evaluation prompt
+    prompt = f"""You are an expert evaluator. Your task: {description}
+
+{rubric_section}
+**Evaluation Details:**
+- User Query: {{prompt}}
+- AI Response: {{response}}
+- Ground Truth Reference: {{ground_truth}}
+
+**Instructions:**
+Carefully evaluate the AI response using the grading rubric above.
+
+**Required Output Format:**
+Return ONLY a valid JSON object with these two fields:
+{{
+  "score": <your_score>,
+  "explanation": "Brief explanation of your score"
+}}
+
+Do not include any other text outside the JSON object."""
+    
+    return prompt
+
+def load_metrics_from_csv():
+    """Load metrics from CSV and auto-generate evaluation prompts."""
+    if METRICS_CONFIG_DATA is None:
+        return []
+    
+    metric_configs = []
+    for _, row in METRICS_CONFIG_DATA.iterrows():
+        metric_type_str = row['type'].strip().lower()
+        if metric_type_str == 'binary':
+            metric_type = MetricType.BINARY
+        elif metric_type_str in ['1-5_scale', 'scale_1_5']:
+            metric_type = MetricType.SCALE_1_5
+        elif metric_type_str == 'percentage':
+            metric_type = MetricType.PERCENTAGE
+        else:
+            metric_type = MetricType.BINARY
+        
+        # Check if using new format (grading_rubric) or old format (evaluation_prompt)
+        if 'grading_rubric' in row and pd.notna(row.get('grading_rubric')):
+            # NEW FORMAT: Auto-generate evaluation prompt from grading rubric
+            grading_rubric = str(row['grading_rubric']).strip()
+            prompt_template = auto_generate_evaluation_prompt(
+                metric_name=row['name'].strip(),
+                metric_type=metric_type_str,
+                description=row.get('description', '').strip(),
+                grading_rubric=grading_rubric
+            )
+            print(f"✅ {row['name'].strip()} - Auto-generated prompt from grading rubric")
+        elif 'evaluation_prompt' in row and pd.notna(row.get('evaluation_prompt')):
+            # OLD FORMAT: Use evaluation_prompt directly (backward compatibility)
+            prompt_template = row['evaluation_prompt'].strip()
+            print(f"✅ {row['name'].strip()} - Using provided evaluation_prompt")
+        else:
+            # Fallback: Generate basic prompt from description
+            prompt_template = auto_generate_evaluation_prompt(
+                metric_name=row['name'].strip(),
+                metric_type=metric_type_str,
+                description=row.get('description', '').strip(),
+                grading_rubric=""
+            )
+            print(f"⚠️ {row['name'].strip()} - No rubric or prompt provided, using basic prompt")
+        
+        # Ground truth file matching (PM provides filename, code matches to uploaded files)
+        gt_file_value = row.get('ground_truth_file_path', '').strip()
+        
+        metric_config = MetricConfig(
+            name=row['name'].strip(),
+            metric_type=metric_type,
+            description=row.get('description', '').strip(),
+            prompt_template=prompt_template,
+            threshold=float(row['threshold']),
+            ground_truth_column=row['ground_truth_column'].strip(),
+            ground_truth_file_path=gt_file_value
+        )
+        
+        # Show which GT file this metric will use
+        if gt_file_value:
+            gt_filename = os.path.basename(gt_file_value)
+            print(f"   📚 Ground truth: {gt_filename} → column '{row['ground_truth_column'].strip()}'")
+        
+        metric_configs.append(metric_config)
+    
+    return metric_configs
+
+def get_safe_output_directory():
+    """Get a safe directory for output files with proper error handling."""
+    import tempfile
+    import os
+    
+    # Try multiple directory options in order of preference
+    possible_dirs = [
+        # Current working directory (most likely to work)
+        os.path.join(os.getcwd(), "llm_eval_artifacts"),
+        # User's home directory
+        os.path.join(os.path.expanduser("~"), "llm_eval_artifacts"),
+        # System temp directory
+        os.path.join(tempfile.gettempdir(), "llm_eval_artifacts"),
+        # Fallback to current directory
+        "llm_eval_artifacts"
+    ]
+    
+    for out_dir in possible_dirs:
+        try:
+            # Create directory if it doesn't exist
+            os.makedirs(out_dir, exist_ok=True)
+            
+            # Test write permissions by creating a test file
+            test_file = os.path.join(out_dir, "test_write.tmp")
+            with open(test_file, 'w') as f:
+                f.write("test")
+            os.remove(test_file)
+            
+            print(f"✅ Using output directory: {out_dir}")
+            return out_dir
+            
+        except (PermissionError, OSError) as e:
+            print(f"⚠️ Cannot use {out_dir}: {e}")
+            continue
+    
+    # If all else fails, use current directory
+    print("⚠️ Using current directory as fallback")
+    return "llm_eval_artifacts"
+
+# Load metrics
+metric_configs = load_metrics_from_csv()
+
+if not metric_configs:
+    print("❌ No valid metrics!")
+else:
+    # Create evaluator
+    evaluator = LLMJudgeEvaluator(
+        judge_model=JUDGE_MODEL,
+        metrics=metric_configs,
+        ground_truth_data=ground_truth_data
+    )
+    
+    # Run evaluation
+    print("="*60)
+    print("🚀 STARTING EVALUATION")
+    print("="*60)
+    
+    start_time = time.time()
+    results_df = evaluator.evaluate_dataset(EVALUATION_DATA)
+    eval_time = time.time() - start_time
+    
+    print(f"\n{'='*60}")
+    print(f"✅ COMPLETE in {eval_time:.1f}s")
+    print(f"{'='*60}")
+    
+    # Display summary
+    total = len(results_df)
+    passed = len(results_df[results_df['status'] == '✅'])
+    pass_rate = (passed / total) * 100 if total > 0 else 0
+    
+    print(f"\n📊 RESULTS SUMMARY")
+    print(f"{'='*60}")
+    print(f"Total Evaluations: {total}")
+    print(f"Passed: {passed}")
+    print(f"Failed: {total - passed}")
+    print(f"Pass Rate: {pass_rate:.1f}%")
+    print(f"{'='*60}")
+    
+    # Per-metric results
+    for metric_name in results_df['metric_name'].unique():
+        metric_results = results_df[results_df['metric_name'] == metric_name]
+        metric_passed = len(metric_results[metric_results['status'] == '✅'])
+        metric_total = len(metric_results)
+        metric_pass_rate = (metric_passed / metric_total) * 100 if metric_total > 0 else 0
+        avg_score = metric_results['score'].mean()
+        
+        print(f"\n🔹 {metric_name}:")
+        print(f"   Pass Rate: {metric_pass_rate:.1f}% ({metric_passed}/{metric_total})")
+        print(f"   Avg Score: {avg_score:.2f}")
+        print(f"   Threshold: {metric_results['threshold'].iloc[0]}")
+    
+    # Store globally
+    globals()['results_df'] = results_df
+    
+    # Log to MLflow
+    mlflow.set_experiment(f"/Users/{dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()}/llm_evaluation_experiment")
+    
+    with mlflow.start_run(run_name=f"eval_{JUDGE_MODEL}_{time.strftime('%Y%m%d_%H%M%S')}"):
+        mlflow.log_param("judge_model", JUDGE_MODEL)
+        mlflow.log_param("num_samples", len(EVALUATION_DATA))
+        mlflow.log_param("metrics", ",".join([cfg.name for cfg in metric_configs]))
+        
+        mlflow.log_metric("overall_pass_rate", pass_rate)
+        mlflow.log_metric("total_evaluations", total)
+        mlflow.log_metric("passed_evaluations", passed)
+        
+        for metric_name in results_df['metric_name'].unique():
+            metric_results = results_df[results_df['metric_name'] == metric_name]
+            scores = metric_results['score'].tolist()
+            numeric_scores = [s for s in scores if isinstance(s, (int, float))]
+            
+            if numeric_scores:
+                mean_score = sum(numeric_scores) / len(numeric_scores)
+                threshold = metric_results['threshold'].iloc[0]
+                pass_count = sum(1 for s in numeric_scores if s >= threshold)
+                pass_rate_metric = (pass_count / len(numeric_scores)) * 100
+                
+                mlflow.log_metric(f"{metric_name}_mean", float(mean_score))
+                mlflow.log_metric(f"{metric_name}_pass_rate", float(pass_rate_metric))
+        
+        # Save results with improved error handling
+        try:
+            out_dir = get_safe_output_directory()
+            csv_path = os.path.join(out_dir, f"results_{int(time.time())}.csv")
+            results_df.to_csv(csv_path, index=False)
+            mlflow.log_artifact(csv_path, artifact_path="tables")
+            print(f"✅ Results saved to: {csv_path}")
+        except Exception as e:
+            print(f"❌ Error saving results: {e}")
+            print("📝 Results are still available in the 'results_df' variable")
+    
+    print(f"\n✅ Results logged to MLflow")


### PR DESCRIPTION
Add `get_safe_output_directory` function and use it for MLflow artifact logging to resolve `PermissionError` during result saving.

The previous implementation hardcoded `/tmp/llm_eval_artifacts` which often led to `PermissionError`. The new function attempts to find a writable directory (current, home, then system temp) and tests write permissions, making the artifact saving more reliable across different environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-37979eb5-a8d2-4fb0-b8bb-19426d91051c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37979eb5-a8d2-4fb0-b8bb-19426d91051c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

